### PR TITLE
Updates for JSON-RPC API Format (client groups and volume object)

### DIFF
--- a/lib/snapdance.pm
+++ b/lib/snapdance.pm
@@ -135,16 +135,18 @@ get '/api/setsound/:room/:volume' => sub {
         my $results = $self->do_request(
             { 'jsonrpc' => '2.0', 'method' => 'Server.GetStatus' } );
         die "No clients connected to server"
-          unless ref $results->{result}{clients}
-          && scalar @{ $results->{result}{clients} };
+          unless ref $results->{result}{groups}
+          && scalar @{ $results->{result}{groups} };
 
         my @clients;
-        foreach my $set ( @{ $results->{result}{clients} } ) {
-            push @clients,
-              {
-                mac    => $set->{'host'}{'mac'},
-                volume => $set->{'config'}{'volume'}{'percent'}
-              };
+        foreach my $group ( @{ $results->{result}{groups} } ) {
+            foreach my $set ( @{ $group->{clients} } ) {
+                push @clients,
+                  {
+                    mac    => $set->{'host'}{'mac'},
+                    volume => $set->{'config'}{'volume'}{'percent'}
+                  };
+            }
         }
 
         @clients = sort { $a->{mac} cmp $b->{mac} } @clients;

--- a/lib/snapdance.pm
+++ b/lib/snapdance.pm
@@ -161,7 +161,7 @@ get '/api/setsound/:room/:volume' => sub {
             {
                 'jsonrpc' => '2.0',
                 'method'  => 'Client.SetVolume',
-                'params'  => { 'client' => $client, 'volume' => int($volume) },
+                'params'  => { 'client' => $client, 'volume' => { 'percent' => int($volume) } },
 
                 #'id' => 1 # request id
             }


### PR DESCRIPTION
In December, there were a couple of breaking changes to the `snapcast` JSON-RPC API. The changes have not yet made it into a release (the latest release is still `v0.10.0` from Nov 17, 2016), but as I've already fixed things on my end I figured I'd send a PR in case it was useful down the road.

Changes:
* Added the concept of "groups", which changed the response format of `Server.GetStatus`
* Changed the parameter format of `Client.SetVolume` ([see commit here](https://github.com/badaix/snapcast/commit/a133c606619ea52651e6af977d9a1271a5762c2d))

This not backwards-compatible with the old API format, and may change again before an official release, so _caveat emptor_ :)