### PR TITLE
Updates for Snapcast 0.11.0 (+ some misc fixes)

### DIFF
--- a/lib/snapdance.pm
+++ b/lib/snapdance.pm
@@ -135,11 +135,11 @@ get '/api/setsound/:room/:volume' => sub {
         my $results = $self->do_request(
             { 'jsonrpc' => '2.0', 'method' => 'Server.GetStatus' } );
         die "No clients connected to server"
-          unless ref $results->{result}{groups}
-          && scalar @{ $results->{result}{groups} };
+          unless ref $results->{result}{server}{groups}
+          && scalar @{ $results->{result}{server}{groups} };
 
         my @clients;
-        foreach my $group ( @{ $results->{result}{groups} } ) {
+        foreach my $group ( @{ $results->{result}{server}{groups} } ) {
             foreach my $set ( @{ $group->{clients} } ) {
                 push @clients,
                   {
@@ -161,7 +161,7 @@ get '/api/setsound/:room/:volume' => sub {
             {
                 'jsonrpc' => '2.0',
                 'method'  => 'Client.SetVolume',
-                'params'  => { 'client' => $client, 'volume' => { 'percent' => int($volume) } },
+                'params'  => { 'id' => $client, 'volume' => { 'percent' => int($volume) } },
 
                 #'id' => 1 # request id
             }

--- a/lib/snapdance.pm
+++ b/lib/snapdance.pm
@@ -56,7 +56,7 @@ get '/api/setsound/:room/:volume' => sub {
     my $reply;
     if ( !$error ) {
         $reply = $SNAPCAST->set_volume( $room, $volume );
-        $error = "Volume queries failed" unless $reply->{'result'} = $volume;
+        $error = "Volume queries failed" unless exists $reply->{'result'}{'volume'}{'percent'} && $reply->{'result'}{'volume'}{'percent'} == $volume;
     }
 
     return to_json { status => 0, msg => $error } if $error;

--- a/lib/snapdance.pm
+++ b/lib/snapdance.pm
@@ -141,6 +141,7 @@ get '/api/setsound/:room/:volume' => sub {
         my @clients;
         foreach my $group ( @{ $results->{result}{server}{groups} } ) {
             foreach my $client ( @{ $group->{clients} } ) {
+                next if !$client->{connected}; # Ignore disconnected clients
                 push @clients,
                   {
                     clientid => $client->{'id'},

--- a/views/index.tt
+++ b/views/index.tt
@@ -1,6 +1,6 @@
 <script>
 function setsound(room, level) {
-    jQuery.get('/api/setsound/'+room+'/'+level, function(data) {
+    jQuery.get('/api/setsound/'+encodeURIComponent(room)+'/'+level, function(data) {
     console.log(data);
     //$("#msg").html(data["text"]);
     });
@@ -53,14 +53,14 @@ function set_all_rooms_to(level) {
         $(".<%= room.id %>").knob({
         'release' : function (v) {
         console.log("<%= room.id %> "+v);
-        setsound( "<%= room.mac %>", v);
+        setsound( "<%= room.clientid %>", v);
         }
         });
         </script>
       </div>
     </div>
     <% END %>
-  </div><!-- /row -->    
+  </div><!-- /row -->
 </div> <!-- /container -->
 
 <div id="footerwrap">

--- a/views/index.tt
+++ b/views/index.tt
@@ -10,7 +10,6 @@ function set_all_rooms_to(level) {
   console.log("All rooms to " + level);
   <% FOREACH room IN rooms %>
   $("#i<%= room.id %>").val(level).trigger('change');
-  setsound("<%= room.id %>", level);
   <% END %>
 }
 </script>


### PR DESCRIPTION
Hello! This PR includes a few things, so let me know if you'd rather me break it apart and submit each part individually.

* Fixed error checking: the set volume route error checking was assigning instead of checking equality
* Updates for snapcast 0.11.0-beta-1: the JSON-RPC API format changed again
* Switching the way clients are identified: as part of the change for 0.11.0, snapcast now supports running multiple snapclients on a single machine. This is done by supplying an optional `--instance` argument, which is then combined with the MAC address in order to generate the client's `id`. e.x. `b8:27:eb:9b:7d:50#2`. If `--instance` is not specified, the client's `id` is simply the MAC address.
* Hiding disconnected clients: snapserver's `Server.GetStatus` response includes each client's connection status, so we can hide clients that aren't currently connected. I acknowledge that this may not be universally desired (I prefer it, personally) so let me know if you disagree.
* Fixing double-send: triggering a `change` event on the volume input automatically triggers a `setsound()` call (at least in Chrome), so there's no need to also call it manually.